### PR TITLE
Filter integration

### DIFF
--- a/ground_plane_removal/include/ground_plane_removal/GroundPlaneRemover.hpp
+++ b/ground_plane_removal/include/ground_plane_removal/GroundPlaneRemover.hpp
@@ -30,6 +30,7 @@ public:
 
 protected:
 	PointCloud::Ptr applyCropBox(PointCloud::ConstPtr input, const GroundPlaneCropBoxParameters &p) const;
+	PointCloud::Ptr applyVoxelGrid(PointCloud::ConstPtr input, const GroundPlaneVoxelGridParameters &p) const;
 	PointCloud::Ptr inputCloud_;
 	PointCloud::Ptr noGroundPlaneCloud_;
 private:

--- a/ground_plane_removal/include/ground_plane_removal/Parameters.hpp
+++ b/ground_plane_removal/include/ground_plane_removal/Parameters.hpp
@@ -21,12 +21,20 @@ struct GroundPlaneCropBoxParameters
   double maxY_= 50.0;
   double minZ_= -10.0;
   double maxZ_= 10.0;
+};
 
+struct GroundPlaneVoxelGridParameters
+{
+  double leafSizeX_ = 0.02;
+  double leafSizeY_ = 0.02;
+  double leafSizeZ_ = 0.02;
 };
 
 
 struct GroundPlaneRemoverParam {
+	bool isUseVoxelGrid_ = true;
 	GroundPlaneCropBoxParameters cropBox_;
+	GroundPlaneVoxelGridParameters voxelGrid_;
 };
 
 struct ElevationMapGroundPlaneRemoverParam : public GroundPlaneRemoverParam {
@@ -36,9 +44,13 @@ struct ElevationMapGroundPlaneRemoverParam : public GroundPlaneRemoverParam {
 	double medianFilteringRadius_ = 2.0;
 	int medianFilterDownsampleFactor_  = 1;
 	bool isUseMedianFiltering_ = true;
+	bool isUseCropBox_ = true;
 };
 
 std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& p);
 void loadParameters(const YAML::Node &node, GroundPlaneCropBoxParameters *p);
+
+std::ostream& operator<<(std::ostream& out, const GroundPlaneVoxelGridParameters& p);
+void loadParameters(const YAML::Node &node, GroundPlaneVoxelGridParameters *p);
 
 } // namespace ground_removal

--- a/ground_plane_removal/src/ElevationMapGroundPlaneRemover.cpp
+++ b/ground_plane_removal/src/ElevationMapGroundPlaneRemover.cpp
@@ -115,6 +115,14 @@ const grid_map::GridMap& ElevationMapGroundPlaneRemover::getElevationMap() const
 }
 
 void ElevationMapGroundPlaneRemover::removeGroundPlane() {
+	if (param_.isUseCropBox_){
+		inputCloud_ = applyCropBox(inputCloud_, param_.cropBox_);
+	}
+	if (param_.isUseVoxelGrid_) {
+		inputCloud_ = applyVoxelGrid(inputCloud_, param_.voxelGrid_);
+	}
+
+
 	pclToGridMap_.setInputCloud(inputCloud_);
 	pclToGridMap_.initializeGridMapGeometryFromInputCloud();
 	pclToGridMap_.addLayerFromInputCloud(elevationLayer);

--- a/ground_plane_removal/src/Parameters.cpp
+++ b/ground_plane_removal/src/Parameters.cpp
@@ -51,6 +51,33 @@ std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& 
   return out;
 }
 
+void loadParameters(const YAML::Node &node, GroundPlaneVoxelGridParameters *p) {
+	p->leafSizeX_ = node["leaf_size_x"].as<double>();
+	p->leafSizeY_ = node["leaf_size_y"].as<double>();
+	p->leafSizeZ_ = node["leaf_size_z"].as<double>();
+}
+
+std::ostream& operator<<(std::ostream& out, const GroundPlaneVoxelGridParameters& p) {
+  out << "┌────────────────────────────────────────────────────┐\n";
+  out << "│                GroundPlaneVoxelGridParameters      │\n";
+  out << "├─────────────────────────────────┬──────────────────┤\n";
+  out << "│ " << std::left << std::setw(31) << "size X"
+      << " │ " << std::right << std::setw(16) << std::fixed
+      << std::setprecision(4) << p.leafSizeX_  << " │\n";
+  out << "├─────────────────────────────────┼──────────────────┤\n";
+  out << "│ " << std::left << std::setw(31) << "size Y"
+      << " │ " << std::right << std::setw(16) << std::fixed
+      << std::setprecision(4) << p.leafSizeY_ << " │\n";
+  out << "├─────────────────────────────────┼──────────────────┤\n";
+  out << "│ " << std::left << std::setw(31) << "size Z"
+      << " │ " << std::right << std::setw(16) << std::fixed
+      << std::setprecision(4) << p.leafSizeZ_ << " │\n";
+  out << "├─────────────────────────────────┼──────────────────┤\n";
+
+
+  return out;
+}
+
 } // namespace ground_removal
 
 

--- a/tree_detection/include/tree_detection/Parameters.hpp
+++ b/tree_detection/include/tree_detection/Parameters.hpp
@@ -25,18 +25,7 @@ struct TreeDetectionParameters {
 	bool isPrintTiming_ = false;
 };
 
-struct CloudCroppingParameters {
-	double cropBoxMinX_ = -50.0;
-	double cropBoxMaxX_ = 50.0;
-	double cropBoxMinY_ = -50.0;
-	double cropBoxMaxY_ = 50.0;
-	double cropBoxMinZ_ = -10.0;
-	double cropBoxMaxZ_ = 20.0;
-};
-
 void loadParameters(const YAML::Node &node, TreeDetectionParameters *p);
 void loadParameters(const std::string &filename, TreeDetectionParameters *p);
-void loadParameters(const YAML::Node &node, CloudCroppingParameters *p);
-void loadParameters(const std::string &filename, CloudCroppingParameters *p);
 
 } // namespace tree_detection

--- a/tree_detection/src/Parameters.cpp
+++ b/tree_detection/src/Parameters.cpp
@@ -31,21 +31,4 @@ void loadParameters(const std::string &filename, TreeDetectionParameters *p) {
 	loadParameters(node["tree_detection"], p);
 }
 
-void loadParameters(const YAML::Node &node, CloudCroppingParameters *p) {
-	p->cropBoxMinX_ = node["crop_box_minX"].as<double>();
-	p->cropBoxMaxX_ = node["crop_box_maxX"].as<double>();
-	p->cropBoxMinY_ = node["crop_box_minY"].as<double>();
-	p->cropBoxMaxY_ = node["crop_box_maxY"].as<double>();
-	p->cropBoxMinZ_ = node["crop_box_minZ"].as<double>();
-	p->cropBoxMaxZ_ = node["crop_box_maxZ"].as<double>();
-}
-void loadParameters(const std::string &filename, CloudCroppingParameters *p) {
-	YAML::Node node = YAML::LoadFile(filename);
-
-	if (node.IsNull()) {
-		throw std::runtime_error("Tree cloud parameters loading failed");
-	}
-	loadParameters(node["cropping"], p);
-}
-
 } // namespace tree_detection

--- a/tree_detection_ros/config/tree_detection.yaml
+++ b/tree_detection_ros/config/tree_detection.yaml
@@ -1,5 +1,10 @@
 ground_plane_removal:
-  cropbox: 
+  voxel_grid:
+    leaf_size_x: 0.02
+    leaf_size_y: 0.02
+    leaf_size_z: 0.02
+  cropbox:
+    is_use_voxel_grid: true
     crop_box_minX: -100.0
     crop_box_maxX: 100.0
     crop_box_minY: -100.0
@@ -7,6 +12,8 @@ ground_plane_removal:
     crop_box_minZ: 0.0
     crop_box_maxZ: 20.0
   elevation_map:
+    is_use_crop_box: true
+    is_use_voxel_grid: true   # applied to point cloud
     min_height_above_ground: 0.2
     max_height_above_ground: 3.5
     is_use_median_filter: true
@@ -31,18 +38,18 @@ ground_plane_removal:
       is_remove_outliers: false
       mean_K: 10
       stddev_threshold: 1.0
-    downsampling:
+    downsampling:   # use inside elevation mapping
       is_downsample_cloud: false
       voxel_size:
         x: 0.02
         y: 0.02
         z: 0.02 
-    grid_map:
-      min_num_points_per_cell: 1
-      max_num_points_per_cell: 100000
-      resolution: 0.5
-  
+      grid_map:
+        min_num_points_per_cell: 1
+        max_num_points_per_cell: 100000
+        resolution: 0.5
 
+  
 
 
 # Tree specific parameters

--- a/tree_detection_ros/config/tree_detection.yaml
+++ b/tree_detection_ros/config/tree_detection.yaml
@@ -1,19 +1,19 @@
 ground_plane_removal:
   voxel_grid:
-    leaf_size_x: 0.02
-    leaf_size_y: 0.02
-    leaf_size_z: 0.02
+    leaf_size_x: 0.05
+    leaf_size_y: 0.05
+    leaf_size_z: 0.05
   cropbox:
     is_use_voxel_grid: true
     crop_box_minX: -100.0
     crop_box_maxX: 100.0
     crop_box_minY: -100.0
     crop_box_maxY: 100.0
-    crop_box_minZ: 0.0
+    crop_box_minZ: -2.0
     crop_box_maxZ: 20.0
   elevation_map:
-    is_use_crop_box: true
-    is_use_voxel_grid: true   # applied to point cloud
+    is_use_crop_box: false
+    is_use_voxel_grid: false   # applied to point cloud
     min_height_above_ground: 0.2
     max_height_above_ground: 3.5
     is_use_median_filter: true
@@ -22,9 +22,9 @@ ground_plane_removal:
     num_processing_threads: 7
     cloud_transform:
       translation:
-        x: 0.0
-        y: 0.0
-        z: 0.0
+        x:  0.0
+        y:  0.0
+        z:  0.0
       rotation: #intrinsic rotation X-Y-Z (r-p-y)sequence
         r: 0.0
         p: 0.0
@@ -38,18 +38,18 @@ ground_plane_removal:
       is_remove_outliers: false
       mean_K: 10
       stddev_threshold: 1.0
-    downsampling:   # use inside elevation mapping
+    downsampling:
       is_downsample_cloud: false
       voxel_size:
         x: 0.02
         y: 0.02
         z: 0.02 
-      grid_map:
-        min_num_points_per_cell: 1
-        max_num_points_per_cell: 100000
-        resolution: 0.5
-
+    grid_map:
+      min_num_points_per_cell: 1
+      max_num_points_per_cell: 100000
+      resolution: 0.5
   
+
 
 
 # Tree specific parameters

--- a/tree_detection_ros/src/creators.cpp
+++ b/tree_detection_ros/src/creators.cpp
@@ -15,6 +15,7 @@ void loadParameters(const std::string &filename, ground_removal::GroundPlaneRemo
 	YAML::Node node = YAML::LoadFile(filename);
 	p->isUseVoxelGrid_ = node["ground_plane_removal"]["cropbox"]["is_use_voxel_grid"].as<bool>();
 	loadParameters(node["ground_plane_removal"]["cropbox"], &p->cropBox_);
+	loadParameters(node["ground_plane_removal"]["voxel_grid"], &p->voxelGrid_);
 
 }
 

--- a/tree_detection_ros/src/creators.cpp
+++ b/tree_detection_ros/src/creators.cpp
@@ -13,6 +13,7 @@ namespace ground_removal {
 void loadParameters(const std::string &filename, ground_removal::GroundPlaneRemoverParam *p) {
 
 	YAML::Node node = YAML::LoadFile(filename);
+	p->isUseVoxelGrid_ = node["ground_plane_removal"]["cropbox"]["is_use_voxel_grid"].as<bool>();
 	loadParameters(node["ground_plane_removal"]["cropbox"], &p->cropBox_);
 
 }
@@ -20,11 +21,16 @@ void loadParameters(const std::string &filename, ground_removal::GroundPlaneRemo
 void loadParameters(const std::string &filename, ground_removal::ElevationMapGroundPlaneRemoverParam *p) {
 
 	YAML::Node node = YAML::LoadFile(filename);
+	loadParameters(node["ground_plane_removal"]["cropbox"], &p->cropBox_);
+	loadParameters(node["ground_plane_removal"]["voxel_grid"], &p->voxelGrid_);
+	
 	auto groundRemoval = node["ground_plane_removal"]["elevation_map"];
 	grid_map::grid_map_pcl::PclLoaderParameters pclLoaderParam;
 	pclLoaderParam.loadParameters(groundRemoval);
 	p->pclConverter_ = pclLoaderParam;
 
+	p->isUseCropBox_ = groundRemoval["is_use_crop_box"].as<bool>();
+	p->isUseVoxelGrid_ = groundRemoval["is_use_voxel_grid"].as<bool>();
 	p->medianFilteringRadius_  = groundRemoval["median_filtering_radius"].as<double>();
 	p->medianFilterDownsampleFactor_ = groundRemoval["median_filter_points_downsample_factor"].as<int>();
 	p->minHeightAboveGround_ = groundRemoval["min_height_above_ground"].as<double>();
@@ -52,7 +58,7 @@ std::unique_ptr<ground_removal::GroundPlaneRemover> groundRemoverFactory(const s
 		groundRemover->setParameters(groundPlaneRemovalParam);
 		ret = std::move(groundRemover);
 	} else {
-		throw std::runtime_error("Unknown groun plane removal strategy!!!");
+		throw std::runtime_error("Unknown ground plane removal strategy!!!");
 	}
 
 	return ret;


### PR DESCRIPTION
- added a voxelgrid filter for the cropbox ground removal
- added a voxelgrid filter and a cropbox for the elevation map ground removal

If the point cloud expansion is too large, the pcl voxelgrid filter outputs a warning in the terminal. An integer overflow seems to happen.

Although, there is already a voxelgrid filter in the computation of the elevation map, a considerable speed up can be obtained by applying a voxelgrid filter before adding the elevationLayer to the grid map (if the point cloud contains a lot of very close points).

Quick Note: the voxelgrid filter used in the pipeline of the grid_map seems to be more performant than the one provided by pcl, as no warning is rising when applying the same leaf size. (It might be that the warning is suppressed by the package) 