### PR TITLE
Point cloud preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The code for tree detection has been developed as a part of research on autonomo
 ## Packages in this repo
 This repository consists of following packages:
 
+* ***point_cloud_preprocessig*** is a package used to preprocess the point cloud before removing the ground plane
 * ***ground_plane_removal*** is a lightweight package for ground plane removal. 
 * ***tree_detection*** implements the core algorithm for tree detection. 
 * ***tree_detection_ros*** adds visualization and I/O handling for easier usage. This package is tightly integrated with ROS.
@@ -91,6 +92,10 @@ roslaunch tree_detection_ros tree_detection.launch
 The node publishes the input pointcloud, the pointcloud with the ground removed and the elevation map used to remove the ground plane. The detected trees will be marked with green cylinders and bounding boxes. The visualization should appar in the Rviz window.
 
 Note that the computation can last for up to 7-9 minutes for larger datasets (e.g. forest4.pcd and forest5.pcd). This can be shortened with different tuning, downsampling or voxelizing the point clouds.
+
+If the choice is made to use the point cloud preprocessing package, special care needs to be taken that the voxel grid leaf size is chosen big enough. (Otherwise, there is an integer overflow in the pcl library and a warning is popping up in the terminal.) In addition, if the ground plane is removed using the elevation map approach, it is important, that the crop box of the preprocessing is not removing partially the point cloud representing the ground plane, else the elevation map will not correctly be generated. This could result to the fact that trees are not detected in the point cloud.
+
+In general, the preprocessing should only be applied to point clouds, which either have an near infinite expansion and/or point which are extremely close to each other. Both phemomena decrease the processing speed of the tree detection significally! The infinite expansion problem can be handled using the crop box in the preprocessing package. The close point problem can be solved using the voxel grid filter in the same package.
 
 
 ## Parameters

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Note that the computation can last for up to 7-9 minutes for larger datasets (e.
 
 If the choice is made to use the point cloud preprocessing package, special care needs to be taken that the voxel grid leaf size is chosen big enough. (Otherwise, there is an integer overflow in the pcl library and a warning is popping up in the terminal.) In addition, if the ground plane is removed using the elevation map approach, it is important, that the crop box of the preprocessing is not removing partially the point cloud representing the ground plane, else the elevation map will not correctly be generated. This could result to the fact that trees are not detected in the point cloud.
 
-In general, the preprocessing should only be applied to point clouds, which either have an near infinite expansion and/or point which are extremely close to each other. Both phemomena decrease the processing speed of the tree detection significally! The infinite expansion problem can be handled using the crop box in the preprocessing package. The close point problem can be solved using the voxel grid filter in the same package.
+In general, the preprocessing should only be applied to point clouds, which either have points far away from the origin and/or which are dense. Both phemomena decrease the processing speed of the tree detection significally! The first phenomenum can be handled using the crop box in the preprocessing package. The second one can be tackled using the voxel grid filter in the same package.
 
 
 ## Parameters

--- a/point_cloud_preprocessing/CMakeLists.txt
+++ b/point_cloud_preprocessing/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 3.5)
+project(point_cloud_preprocessing)
+
+set(CMAKE_CXX_STANDARD 14)
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
+
+set(SRC_FILES
+  src/PointCloudPreprocessor.cpp
+  src/Parameters.cpp
+)
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    ${CATKIN_REQUIRED_COMPONENTS}
+)
+
+
+find_package(PCL 1.10 REQUIRED)
+
+find_package(OpenMP QUIET)
+if (OpenMP_FOUND)
+  add_compile_options("${OpenMP_CXX_FLAGS}")
+  add_definitions(-DGROUND_PLANE_REMOVAL_OPENMP_FOUND=${OpenMP_FOUND})
+endif()
+
+###################################
+## catkin specific configuration ##
+###################################
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+    yaml-cpp
+    ${OpenMP_CXX_LIBRARIES}
+  DEPENDS
+    PCL
+)
+
+
+###########
+## Build ##
+###########
+
+include_directories(
+  include
+  SYSTEM
+    ${PCL_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
+    ${OpenMP_CXX_INCLUDE_DIRS}
+)
+
+link_directories( #only needed for pcl
+  ${PCL_LIBRARY_DIRS}
+)
+
+add_definitions( #only needed for pcl
+  ${PCL_DEFINITIONS}
+)
+
+add_library(${PROJECT_NAME}
+  ${SRC_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${PCL_COMMON_LIBRARIES}
+  ${PCL_IO_LIBRARIES}
+  ${OpenMP_CXX_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+#install(DIRECTORY include/${PROJECT_NAME}/
+#  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#  PATTERN ".svn" EXCLUDE
+#)
+#install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node point_cloud_stitcher_node
+#  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#)
+#
+#install(DIRECTORY
+#  launch
+#  param
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)

--- a/point_cloud_preprocessing/CMakeLists.txt
+++ b/point_cloud_preprocessing/CMakeLists.txt
@@ -22,12 +22,6 @@ find_package(catkin REQUIRED
 
 find_package(PCL 1.10 REQUIRED)
 
-find_package(OpenMP QUIET)
-if (OpenMP_FOUND)
-  add_compile_options("${OpenMP_CXX_FLAGS}")
-  add_definitions(-DGROUND_PLANE_REMOVAL_OPENMP_FOUND=${OpenMP_FOUND})
-endif()
-
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -37,7 +31,6 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
     yaml-cpp
-    ${OpenMP_CXX_LIBRARIES}
   DEPENDS
     PCL
 )
@@ -52,7 +45,6 @@ include_directories(
   SYSTEM
     ${PCL_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
-    ${OpenMP_CXX_INCLUDE_DIRS}
 )
 
 link_directories( #only needed for pcl
@@ -71,7 +63,6 @@ target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${PCL_COMMON_LIBRARIES}
   ${PCL_IO_LIBRARIES}
-  ${OpenMP_CXX_LIBRARIES}
 )
 
 #############

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
@@ -38,5 +38,6 @@ struct PointCloudPreprocessorParam {
 
 std::ostream& operator<<(std::ostream& out, const PointCloudPreprocessorParam& p);
 void loadParameters(const YAML::Node &node, PointCloudPreprocessorParam *p);
+void loadParameters(const std::string &filename, PointCloudPreprocessorParam *p);
 
 } // namespace point_cloud_preprocessing

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
@@ -12,32 +12,31 @@
 namespace point_cloud_preprocessing {
 
 
-// struct GroundPlaneCropBoxParameters
-// {
-//   double minX_ = -50.0;
-//   double maxX_= 50.0;
-//   double minY_= -50.0;
-//   double maxY_= 50.0;
-//   double minZ_= -10.0;
-//   double maxZ_= 10.0;
+struct CropBoxParameters
+{
+	double minX_ = -50.0;
+	double maxX_= 50.0;
+	double minY_= -50.0;
+	double maxY_= 50.0;
+	double minZ_= -10.0;
+	double maxZ_= 10.0;
+};
 
-// };
+struct VoxelGridParameters
+{
+	double leafSizeX_ = 0.02;
+	double leafSizeY_ = 0.02;
+	double leafSizeZ_ = 0.02;
+};
 
+struct PointCloudPreprocessorParam {
+	bool isUseCropBox_ = true;
+	CropBoxParameters cropBox_;
+	bool isUseVoxelGrid_ = true;
+	VoxelGridParameters voxelGrid_;
+};
 
-// struct GroundPlaneRemoverParam {
-// 	GroundPlaneCropBoxParameters cropBox_;
-// };
-
-// struct ElevationMapGroundPlaneRemoverParam : public GroundPlaneRemoverParam {
-// 	grid_map::grid_map_pcl::PclLoaderParameters pclConverter_;
-// 	double minHeightAboveGround_ = 0.1;
-// 	double maxHeightAboveGround_ = 8.0;
-// 	double medianFilteringRadius_ = 2.0;
-// 	int medianFilterDownsampleFactor_  = 1;
-// 	bool isUseMedianFiltering_ = true;
-// };
-
-// std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& p);
-// void loadParameters(const YAML::Node &node, GroundPlaneCropBoxParameters *p);
+std::ostream& operator<<(std::ostream& out, const PointCloudPreprocessorParam& p);
+void loadParameters(const YAML::Node &node, PointCloudPreprocessorParam *p);
 
 } // namespace point_cloud_preprocessing

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/Parameters.hpp
@@ -1,0 +1,43 @@
+/*
+ * Parameters.hpp
+ *
+ *  Created on: Aug 19, 2021
+ *      Author: jelavice
+ */
+
+#pragma once
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+namespace point_cloud_preprocessing {
+
+
+// struct GroundPlaneCropBoxParameters
+// {
+//   double minX_ = -50.0;
+//   double maxX_= 50.0;
+//   double minY_= -50.0;
+//   double maxY_= 50.0;
+//   double minZ_= -10.0;
+//   double maxZ_= 10.0;
+
+// };
+
+
+// struct GroundPlaneRemoverParam {
+// 	GroundPlaneCropBoxParameters cropBox_;
+// };
+
+// struct ElevationMapGroundPlaneRemoverParam : public GroundPlaneRemoverParam {
+// 	grid_map::grid_map_pcl::PclLoaderParameters pclConverter_;
+// 	double minHeightAboveGround_ = 0.1;
+// 	double maxHeightAboveGround_ = 8.0;
+// 	double medianFilteringRadius_ = 2.0;
+// 	int medianFilterDownsampleFactor_  = 1;
+// 	bool isUseMedianFiltering_ = true;
+// };
+
+// std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& p);
+// void loadParameters(const YAML::Node &node, GroundPlaneCropBoxParameters *p);
+
+} // namespace point_cloud_preprocessing

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/PointCloudPreprocessor.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/PointCloudPreprocessor.hpp
@@ -13,16 +13,28 @@
 namespace point_cloud_preprocessing{
 
 
-class PointCloudPreprocessing {
+class PointCloudPreprocessor {
 public:
-	PointCloudPreprocessing() = default;
-	virtual ~PointCloudPreprocessing() = default;
+	PointCloudPreprocessor() = default;
+	virtual ~PointCloudPreprocessor() = default;
 
-    //  void setParameters(const GroundPlaneRemoverParam &p);
-    //  const ElevationMapGroundPlaneRemoverParam &getParameters() const;
+    void setParameters(const PointCloudPreprocessorParam &p);
+    const PointCloudPreprocessorParam &getParameters() const;
+
+	void setInputCloudPtr(PointCloud::ConstPtr inputCloud);
+	void setInputCloud(const PointCloud &inputCloud);
+
+	PointCloud::ConstPtr getPreprocessedCloudPtr() const;
+	const PointCloud &getPreprocessedCloud() const;
+
+	void performPreprocessing();
 
 private:
-	//  ElevationMapGroundPlaneRemoverParam param_;
+	PointCloud::Ptr applyCropBox(PointCloud::ConstPtr input, const CropBoxParameters &p) const;
+	PointCloud::Ptr applyVoxelGrid(PointCloud::ConstPtr input, const VoxelGridParameters &p) const;
+	PointCloud::Ptr inputCloud_;
+	PointCloud::Ptr preprocessedCloud_;
+	PointCloudPreprocessorParam params_;
 
 };
 

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/PointCloudPreprocessor.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/PointCloudPreprocessor.hpp
@@ -1,0 +1,30 @@
+/*
+ * elevationMapGroundPlaneRemover.hpp
+ *
+ *  Created on: Aug 19, 2021
+ *      Author: jelavice
+ */
+
+#pragma once
+#include "point_cloud_preprocessing/Parameters.hpp"
+#include "point_cloud_preprocessing/typedefs.hpp"
+
+
+namespace point_cloud_preprocessing{
+
+
+class PointCloudPreprocessing {
+public:
+	PointCloudPreprocessing() = default;
+	virtual ~PointCloudPreprocessing() = default;
+
+    //  void setParameters(const GroundPlaneRemoverParam &p);
+    //  const ElevationMapGroundPlaneRemoverParam &getParameters() const;
+
+private:
+	//  ElevationMapGroundPlaneRemoverParam param_;
+
+};
+
+
+}  // namespace point_cloud_preprocessing

--- a/point_cloud_preprocessing/include/point_cloud_preprocessing/typedefs.hpp
+++ b/point_cloud_preprocessing/include/point_cloud_preprocessing/typedefs.hpp
@@ -1,0 +1,20 @@
+/*
+ * typedefs.hpp
+ *
+ *  Created on: Aug 19, 2021
+ *      Author: jelavice
+ */
+
+#pragma once
+#include <pcl/PointIndices.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace point_cloud_preprocessing {
+
+using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+using PointIndices = std::vector<pcl::PointIndices>;
+using PointCloudPtrVector = std::vector<PointCloud::Ptr>;
+
+
+} // tree point_cloud_preprocessing

--- a/point_cloud_preprocessing/package.xml
+++ b/point_cloud_preprocessing/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<package format="2">
+
+  <name>point_cloud_preprocessing</name>
+  <version>0.5.0</version>
+  <description>Point Cloud Preprocessing</description>
+
+  <license>BSD</license>
+
+  <author email="jelavice@ethz.ch">EJ</author>
+  <maintainer email="jelavice@ethz.ch">EJr</maintainer>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>pcl</depend>
+
+</package>

--- a/point_cloud_preprocessing/package.xml
+++ b/point_cloud_preprocessing/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD</license>
 
-  <author email="jelavice@ethz.ch">EJ</author>
+  <author email="kapgentun@gmail.com">TK</author>
   <maintainer email="jelavice@ethz.ch">EJr</maintainer>
 
 

--- a/point_cloud_preprocessing/src/Parameters.cpp
+++ b/point_cloud_preprocessing/src/Parameters.cpp
@@ -9,47 +9,74 @@
 
 namespace point_cloud_preprocessing {
 
-// void loadParameters(const YAML::Node &node, GroundPlaneCropBoxParameters *p) {
-// 	p->minX_ = node["crop_box_minX"].as<double>();
-// 	p->maxX_ = node["crop_box_maxX"].as<double>();
-// 	p->minY_ = node["crop_box_minY"].as<double>();
-// 	p->maxY_ = node["crop_box_maxY"].as<double>();
-// 	p->minZ_ = node["crop_box_minZ"].as<double>();
-// 	p->maxZ_ = node["crop_box_maxZ"].as<double>();
-// }
+void loadParameters(const YAML::Node &node, PointCloudPreprocessorParam *p) {
+		p->isUseCropBox_ = node["is_use_crop_box"].as<bool>();
+		p->cropBox_.minX_ = node["crop_box"]["crop_box_minX"].as<double>();
+		p->cropBox_.maxX_ = node["crop_box"]["crop_box_maxX"].as<double>();
+		p->cropBox_.minY_ = node["crop_box"]["crop_box_minY"].as<double>();
+		p->cropBox_.maxY_ = node["crop_box"]["crop_box_maxY"].as<double>();
+		p->cropBox_.minZ_ = node["crop_box"]["crop_box_minZ"].as<double>();
+		p->cropBox_.maxZ_ = node["crop_box"]["crop_box_maxZ"].as<double>();
 
-// std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& p) {
-//   out << "┌────────────────────────────────────────────────────┐\n";
-//   out << "│                 GroundPlaneCropBoxParameters       │\n";
-//   out << "├─────────────────────────────────┬──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << " minX"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.minX_  << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << "max X"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.minX_ << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << "min Y"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.minY_ << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << "max Y"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.maxY_ << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << "min Z"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.minZ_ << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
-//   out << "│ " << std::left << std::setw(31) << "max Z"
-//       << " │ " << std::right << std::setw(16) << std::fixed
-//       << std::setprecision(4) << p.maxZ_ << " │\n";
-//   out << "├─────────────────────────────────┼──────────────────┤\n";
+		p->isUseVoxelGrid_ = node["is_use_voxel_grid"].as<bool>();
+		p->voxelGrid_.leafSizeX_ = node["voxel_grid"]["leaf_size_x"].as<double>();
+		p->voxelGrid_.leafSizeY_ = node["voxel_grid"]["leaf_size_y"].as<double>();
+		p->voxelGrid_.leafSizeZ_ = node["voxel_grid"]["leaf_size_z"].as<double>();
+	}
 
+std::ostream& operator<<(std::ostream& out, const PointCloudPreprocessorParam& p) {
+		out << "┌────────────────────────────────────────────────────┐\n";
+		out << "│             Point Cloud Preprocessor Param         │\n";
+		out << "├─────────────────────────────────┬──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "is use crop box"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.isUseCropBox_  << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box minX"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.minX_  << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box max X"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.minX_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box min Y"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.minY_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box max Y"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.maxY_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box min Z"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.minZ_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "crop box max Z"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.cropBox_.maxZ_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "is use voxel grid"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.isUseVoxelGrid_  << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+		out << "│ " << std::left << std::setw(31) << "voxel grid leaf size X "
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.voxelGrid_.leafSizeX_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
 
-//   return out;
-// }
+		out << "│ " << std::left << std::setw(31) << "voxel grid leaf size Y"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.voxelGrid_.leafSizeY_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+
+		out << "│ " << std::left << std::setw(31) << "voxel grid leaf size Z"
+				<< " │ " << std::right << std::setw(16) << std::fixed
+				<< std::setprecision(4) << p.voxelGrid_.leafSizeZ_ << " │\n";
+		out << "├─────────────────────────────────┼──────────────────┤\n";
+
+  return out;
+}
 
 } // namespace point_cloud_preprocessing
 

--- a/point_cloud_preprocessing/src/Parameters.cpp
+++ b/point_cloud_preprocessing/src/Parameters.cpp
@@ -1,0 +1,57 @@
+/*
+ * Parameters.cpp
+ *
+ *  Created on: Aug 19, 2021
+ *      Author: jelavice
+ */
+#include "point_cloud_preprocessing/Parameters.hpp"
+#include <iomanip>
+
+namespace point_cloud_preprocessing {
+
+// void loadParameters(const YAML::Node &node, GroundPlaneCropBoxParameters *p) {
+// 	p->minX_ = node["crop_box_minX"].as<double>();
+// 	p->maxX_ = node["crop_box_maxX"].as<double>();
+// 	p->minY_ = node["crop_box_minY"].as<double>();
+// 	p->maxY_ = node["crop_box_maxY"].as<double>();
+// 	p->minZ_ = node["crop_box_minZ"].as<double>();
+// 	p->maxZ_ = node["crop_box_maxZ"].as<double>();
+// }
+
+// std::ostream& operator<<(std::ostream& out, const GroundPlaneCropBoxParameters& p) {
+//   out << "┌────────────────────────────────────────────────────┐\n";
+//   out << "│                 GroundPlaneCropBoxParameters       │\n";
+//   out << "├─────────────────────────────────┬──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << " minX"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.minX_  << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << "max X"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.minX_ << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << "min Y"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.minY_ << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << "max Y"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.maxY_ << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << "min Z"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.minZ_ << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+//   out << "│ " << std::left << std::setw(31) << "max Z"
+//       << " │ " << std::right << std::setw(16) << std::fixed
+//       << std::setprecision(4) << p.maxZ_ << " │\n";
+//   out << "├─────────────────────────────────┼──────────────────┤\n";
+
+
+//   return out;
+// }
+
+} // namespace point_cloud_preprocessing
+
+
+

--- a/point_cloud_preprocessing/src/Parameters.cpp
+++ b/point_cloud_preprocessing/src/Parameters.cpp
@@ -9,6 +9,15 @@
 
 namespace point_cloud_preprocessing {
 
+void loadParameters(const std::string &filename, PointCloudPreprocessorParam *p) {
+	YAML::Node node = YAML::LoadFile(filename);
+
+	if (node.IsNull()) {
+		throw std::runtime_error("Point cloud preprocessing parameters loading failed");
+	}
+	loadParameters(node["point_cloud_preprocessing"], p);
+}
+
 void loadParameters(const YAML::Node &node, PointCloudPreprocessorParam *p) {
 		p->isUseCropBox_ = node["is_use_crop_box"].as<bool>();
 		p->cropBox_.minX_ = node["crop_box"]["crop_box_minX"].as<double>();

--- a/point_cloud_preprocessing/src/Parameters.cpp
+++ b/point_cloud_preprocessing/src/Parameters.cpp
@@ -28,9 +28,9 @@ void loadParameters(const YAML::Node &node, PointCloudPreprocessorParam *p) {
 		p->cropBox_.maxZ_ = node["crop_box"]["crop_box_maxZ"].as<double>();
 
 		p->isUseVoxelGrid_ = node["is_use_voxel_grid"].as<bool>();
-		p->voxelGrid_.leafSizeX_ = node["voxel_grid"]["leaf_size_x"].as<double>();
-		p->voxelGrid_.leafSizeY_ = node["voxel_grid"]["leaf_size_y"].as<double>();
-		p->voxelGrid_.leafSizeZ_ = node["voxel_grid"]["leaf_size_z"].as<double>();
+		p->voxelGrid_.leafSizeX_ = node["voxel_grid"]["voxel_grid_leafSizeX"].as<double>();
+		p->voxelGrid_.leafSizeY_ = node["voxel_grid"]["voxel_grid_leafSizeY"].as<double>();
+		p->voxelGrid_.leafSizeZ_ = node["voxel_grid"]["voxel_grid_leafSizeZ"].as<double>();
 	}
 
 std::ostream& operator<<(std::ostream& out, const PointCloudPreprocessorParam& p) {

--- a/point_cloud_preprocessing/src/PointCloudPreprocessor.cpp
+++ b/point_cloud_preprocessing/src/PointCloudPreprocessor.cpp
@@ -1,0 +1,12 @@
+/*
+ * ElevationMapGroundPlaneRemover.cpp
+ *
+ *  Created on: Aug 19, 2021
+ *      Author: jelavice
+ */
+
+#include "point_cloud_preprocessing/PointCloudPreprocessor.hpp"
+
+namespace point_cloud_preprocessing {
+
+}  // namespace point_cloud_preprocessing

--- a/point_cloud_preprocessing/src/PointCloudPreprocessor.cpp
+++ b/point_cloud_preprocessing/src/PointCloudPreprocessor.cpp
@@ -5,8 +5,62 @@
  *      Author: jelavice
  */
 
+#include <pcl/filters/crop_box.h>
+#include <pcl/filters/voxel_grid.h>
+
 #include "point_cloud_preprocessing/PointCloudPreprocessor.hpp"
 
 namespace point_cloud_preprocessing {
+
+    void PointCloudPreprocessor::setParameters(const PointCloudPreprocessorParam &p) {
+	    params_ = p;
+    }
+    const PointCloudPreprocessorParam& PointCloudPreprocessor::getParameters() const {
+        return params_;
+    }
+    void PointCloudPreprocessor::setInputCloudPtr(PointCloud::ConstPtr inputCloud) {
+        setInputCloud(*inputCloud);
+    }
+
+    void PointCloudPreprocessor::setInputCloud(const PointCloud &inputCloud) {
+        inputCloud_.reset(new PointCloud);
+        *inputCloud_ = inputCloud; //copy
+    }
+    void PointCloudPreprocessor::performPreprocessing() {
+        preprocessedCloud_.reset(new PointCloud);
+        *preprocessedCloud_ = *inputCloud_;
+        if (params_.isUseCropBox_) {
+            preprocessedCloud_ = applyCropBox(preprocessedCloud_, params_.cropBox_);
+        }
+        if (params_.isUseVoxelGrid_) {
+            preprocessedCloud_ = applyVoxelGrid(preprocessedCloud_, params_.voxelGrid_);
+        }
+    }
+
+    PointCloud::Ptr PointCloudPreprocessor::applyCropBox(PointCloud::ConstPtr input, const CropBoxParameters &p) const {
+        pcl::CropBox<pcl::PointXYZ> boxFilter;
+        boxFilter.setMin(Eigen::Vector4f(p.minX_, p.minY_, p.minZ_, 1.0));
+        boxFilter.setMax(Eigen::Vector4f(p.maxX_, p.maxY_, p.maxZ_, 1.0));
+        boxFilter.setInputCloud(input);
+        PointCloud::Ptr outputCloud(new PointCloud());
+        boxFilter.filter(*outputCloud);
+        return outputCloud;
+    }
+
+    PointCloud::Ptr PointCloudPreprocessor::applyVoxelGrid(PointCloud::ConstPtr input, const VoxelGridParameters &p) const {
+        pcl::VoxelGrid<pcl::PointXYZ> vox;
+        vox.setInputCloud(input);
+        vox.setLeafSize(p.leafSizeX_, p.leafSizeY_, p.leafSizeZ_);
+        PointCloud::Ptr outputCloud(new PointCloud());
+        vox.filter(*outputCloud);
+	    return outputCloud;
+    }
+
+    PointCloud::ConstPtr PointCloudPreprocessor::getPreprocessedCloudPtr() const {
+	    return preprocessedCloud_;
+    }
+    const PointCloud& PointCloudPreprocessor::getPreprocessedCloud() const {
+        return *preprocessedCloud_;
+    }
 
 }  // namespace point_cloud_preprocessing

--- a/tree_detection_ros/CMakeLists.txt
+++ b/tree_detection_ros/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CATKIN_PACKAGE_DEPENDENCIES
   tree_detection
   ground_plane_removal
+  point_cloud_preprocessing
   pcl_conversions
   sensor_msgs
   visualization_msgs

--- a/tree_detection_ros/config/tree_detection.yaml
+++ b/tree_detection_ros/config/tree_detection.yaml
@@ -1,3 +1,17 @@
+point_cloud_preprocessing:
+  is_use_crop_box: true
+  cropbox: 
+    crop_box_minX: -100.0
+    crop_box_maxX: 100.0
+    crop_box_minY: -100.0
+    crop_box_maxY: 100.0
+    crop_box_minZ: 0.0
+    crop_box_maxZ: 20.0
+  is_use_voxel_grid: true
+  voxel_grid:
+    voxel_grid_leafSizeX: 0.02
+    voxel_grid_leafSizeY: 0.02
+    voxel_grid_leafSizeZ: 0.02
 ground_plane_removal:
   cropbox: 
     crop_box_minX: -100.0

--- a/tree_detection_ros/config/tree_detection.yaml
+++ b/tree_detection_ros/config/tree_detection.yaml
@@ -1,13 +1,13 @@
 point_cloud_preprocessing:
-  is_use_crop_box: true
-  cropbox: 
+  is_use_crop_box: false
+  crop_box: 
     crop_box_minX: -100.0
     crop_box_maxX: 100.0
     crop_box_minY: -100.0
     crop_box_maxY: 100.0
     crop_box_minZ: 0.0
     crop_box_maxZ: 20.0
-  is_use_voxel_grid: true
+  is_use_voxel_grid: false
   voxel_grid:
     voxel_grid_leafSizeX: 0.02
     voxel_grid_leafSizeY: 0.02

--- a/tree_detection_ros/package.xml
+++ b/tree_detection_ros/package.xml
@@ -15,6 +15,7 @@
 	<buildtool_depend>catkin</buildtool_depend>
 	<depend>tree_detection</depend>
 	<depend>ground_plane_removal</depend>
+	<depend>point_cloud_preprocessing</depend>
 	<depend>pcl_conversions</depend>
 	<depend>sensor_msgs</depend>
 	<depend>visualization_msgs</depend>


### PR DESCRIPTION
Create own package for the preprocessing of the input point cloud. The preprocessing is required if the point cloud contains points, which are extremely close to each other or which are very far from each other.

The preprocessing is only working correctly if the leaf size is big enough compared to the crop box volume that an integer variable inside the pcl voxel grid filter is not overflowing. A note regarding this was made in the readme.